### PR TITLE
Change pradiator to a different port

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@ First create a Github access token for this application at
 https://github.com/settings/tokens/new. Check `repo` scope if you want to
 access private repositories' pull requests.  Then create a new JSON file to
 `./config.json` and fill in the access token and repositories you want
-to see pull requests from.
+to see pull requests from. You can also add port to the config.json if you 
+want to use a different port locally, this is optional though.
 
 Example config file:
 ```
 {
   "accessToken": "YOUR_ACCESS_TOKEN_HERE",
-  "repositories": ["jjuutila/pradiator"]
+  "repositories": ["jjuutila/pradiator"],
+  "port": 8787		// This is optional. Use this if you want a different port.
 }
 ```
 

--- a/server.js
+++ b/server.js
@@ -3,7 +3,7 @@ var https = require('https');
 var path = require('path');
 var fs = require('fs');
 
-var PORT = 8888;
+var PORT = 8787;
 
 var app = express();
 

--- a/server.js
+++ b/server.js
@@ -3,7 +3,7 @@ var https = require('https');
 var path = require('path');
 var fs = require('fs');
 
-var DefaultPort = 8787;
+var DEFAULT_PORT = 8787;
 
 var app = express();
 
@@ -17,7 +17,7 @@ if ((!config.accessToken) || (config.accessToken === '')) {
     throw new Error("No 'accessToken' supplied in config.json!");
 }
 
-var port = config.port || DefaultPort;
+var port = config.port || DEFAULT_PORT;
 
 // gets the configured list of repositories
 //

--- a/server.js
+++ b/server.js
@@ -3,7 +3,7 @@ var https = require('https');
 var path = require('path');
 var fs = require('fs');
 
-var PORT = 8888;
+var DefaultPort = 8787;
 
 var app = express();
 
@@ -16,6 +16,8 @@ var config = require('./config.json');
 if ((!config.accessToken) || (config.accessToken === '')) {
     throw new Error("No 'accessToken' supplied in config.json!");
 }
+
+var port = config.port || DefaultPort;
 
 // gets the configured list of repositories
 //
@@ -71,6 +73,6 @@ app.get('/prs/:owner/:repo', function(req, res) {
 });
 
 app.listen(PORT, function() {
-    console.log('pradiator server started at http://localhost:' + PORT + '/');
+    console.log('pradiator server started at http://localhost:' + port + '/');
 });
 


### PR DESCRIPTION
Port 8888 is default proxying port on some proxying software like Charles. Change pradiator's default to a different one to avoid conflict.
